### PR TITLE
Changes made while doing localization comparisons

### DIFF
--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -165,6 +165,8 @@ void pf_init(pf_t *pf, pf_vector_t mean, pf_matrix_t cov)
 
   //set converged to 0
   pf_init_converged(pf);
+
+  //allow converged to be 1 if we actually start out converged
   pf_update_converged(pf);
 
   return;
@@ -203,6 +205,8 @@ void pf_init_model(pf_t *pf, pf_init_model_fn_t init_fn, void *init_data)
  
   //set converged to 0
   pf_init_converged(pf);
+
+  //allow converged to be 1 if we are actually converged from the start
   pf_update_converged(pf); 
 
   return;

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -200,15 +200,11 @@ void pf_init_model(pf_t *pf, pf_init_model_fn_t init_fn, void *init_data)
 
   // Re-compute cluster statistics
   pf_cluster_stats(pf, set);
-<<<<<<< HEAD
-  pf_update_converged(pf); 
  
-=======
-  
   //set converged to 0
   pf_init_converged(pf);
+  pf_update_converged(pf); 
 
->>>>>>> a250a51100edcf5c1edd493c1282a7dad7b1d7fb
   return;
 }
 

--- a/amcl/src/amcl/pf/pf.c
+++ b/amcl/src/amcl/pf/pf.c
@@ -159,6 +159,7 @@ void pf_init(pf_t *pf, pf_vector_t mean, pf_matrix_t cov)
     
   // Re-compute cluster statistics
   pf_cluster_stats(pf, set);
+  pf_update_converged(pf);
 
   return;
 }
@@ -193,7 +194,8 @@ void pf_init_model(pf_t *pf, pf_init_model_fn_t init_fn, void *init_data)
 
   // Re-compute cluster statistics
   pf_cluster_stats(pf, set);
-  
+  pf_update_converged(pf); 
+ 
   return;
 }
 

--- a/amcl/src/amcl/sensors/amcl_laser.cpp
+++ b/amcl/src/amcl/sensors/amcl_laser.cpp
@@ -479,7 +479,7 @@ double AMCLLaser::LikelihoodFieldModelProb(AMCLLaserData *data, pf_sample_set_t*
     bool error = false; 
 
     if(skipped_beam_count >= (beam_ind * self->beam_skip_error_threshold)){
-      fprintf(stderr, "Over 90%% of the observations were not in the map - looks like pf converged to wrong pose - integrating all observations\n");
+      fprintf(stderr, "Over %d%% of the observations were not in the map - looks like pf converged to wrong pose - integrating all observations\n", (int)(self->beam_skip_error_threshold*100));
       error = true; 
     }
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1504,7 +1504,7 @@ AmclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedCons
     // transformation for on-the-move pose-setting, so ignoring this
     // startup condition doesn't really cost us anything.
     if(sent_first_transform_)
-      ROS_WARN("Failed to transform initial pose in time (%s)", e.what());
+      ROS_WARN("Failed to transform initial pose in time (%s), using identity transform for the tiny odometric change since initial pose was broadcast", e.what());
     tx_odom.setIdentity();
   }
 

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -1321,7 +1321,6 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
                                             global_frame_id_, odom_frame_id_);
         this->tfb_->sendTransform(tmp_tf_stamped);
         sent_first_transform_ = true;
-        ROS_INFO("tf_broadcast_ was true, broadcasting");
       }
     }
     else

--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -118,6 +118,7 @@ class AmclNode
 
     tf::Transform latest_tf_, latest_tf_for_odom_;
     bool latest_tf_valid_;
+    bool new_initial_pose_received_;
 
     // Pose-generating function used to uniformly distribute particles over
     // the map
@@ -289,7 +290,8 @@ AmclNode::AmclNode() :
         initial_pose_hyp_(NULL),
         first_map_received_(false),
         first_reconfigure_call_(true),
-	odom_only_(false)
+	odom_only_(false),
+	new_initial_pose_received_(false)
 {
   boost::recursive_mutex::scoped_lock l(configuration_mutex_);
 
@@ -1280,9 +1282,13 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
       latest_tf_valid_ = true;
 
       private_nh_.getParam("odom_only", odom_only_);
-      if (!odom_only_)
+      if (!odom_only_ || new_initial_pose_received_)
       {
-	  latest_tf_for_odom_ = latest_tf_;
+        latest_tf_for_odom_ = latest_tf_;
+        if (new_initial_pose_received_) {
+          new_initial_pose_received_ = false;
+          ROS_INFO("got new initial pose, setting latest_tf_for_odom to latest_tf");
+        }
       }
       
       if (tf_broadcast_ == true && !odom_only_)
@@ -1297,14 +1303,16 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
         this->tfb_->sendTransform(tmp_tf_stamped);
         sent_first_transform_ = true;
       }
-      else if (odom_only_)
+      else if (tf_broadcast_ == true && odom_only_)
       {
-	  ros::Time transform_expiration = (laser_scan->header.stamp +
-					    transform_tolerance_);
-	  tf::StampedTransform tmp_tf_stamped(latest_tf_for_odom_.inverse(),
+        ros::Time transform_expiration = (laser_scan->header.stamp +
+       				    transform_tolerance_);
+        tf::StampedTransform tmp_tf_stamped(latest_tf_for_odom_.inverse(),
                                             transform_expiration,
                                             global_frame_id_, odom_frame_id_);
-	  this->tfb_->sendTransform(tmp_tf_stamped);
+        this->tfb_->sendTransform(tmp_tf_stamped);
+        sent_first_transform_ = true;
+        ROS_INFO("tf_broadcast_ was true, broadcasting");
       }
     }
     else
@@ -1325,7 +1333,7 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
                                           global_frame_id_, odom_frame_id_);
       this->tfb_->sendTransform(tmp_tf_stamped);
     }
-    else if (odom_only_)
+    else if (tf_broadcast_ == true && odom_only_)
     {
 	ros::Time transform_expiration = (laser_scan->header.stamp +
 					  transform_tolerance_);
@@ -1362,7 +1370,14 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
 
   if((publish_basic_pose_ && (!publish_basic_pose_on_convergence_ || pf_->converged)) || 
      publish_test_frame_ || draw_laser_points_){
-    tf::Pose map_pose = latest_tf_.inverse() * odom_pose;
+    tf::Pose map_pose;
+    if (!odom_only_) {
+      map_pose = latest_tf_.inverse() * odom_pose;
+    }
+    else {
+      map_pose = latest_tf_for_odom_.inverse() * odom_pose;
+    }
+
     double yaw,pitch,roll;
     map_pose.getBasis().getEulerYPR(yaw, pitch, roll);
       
@@ -1375,19 +1390,19 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
     p_basic.pose.position.y = map_pose.getOrigin().y();
     tf::quaternionTFToMsg(tf::createQuaternionFromYaw(yaw),
                           p_basic.pose.orientation);
-      
     if(publish_basic_pose_ && (!publish_basic_pose_on_convergence_ || pf_->converged)){
       pose_basic_pub_.publish(p_basic);
     }
 
     if(publish_test_frame_){        
       //looks like some issue with the timestamps here 
+      boost::shared_ptr<tf::Transform> test_base_tf_ptr;
       tf::Transform test_base_tf(tf::createQuaternionFromYaw(yaw), 
-                                 tf::Vector3(map_pose.getOrigin().x(), 
-                                             map_pose.getOrigin().y(), 
-                                             0.0));
-        
-      tf::Stamped<tf::Pose> test_base_to_map(test_base_tf, 
+				 tf::Vector3(map_pose.getOrigin().x(), 
+					     map_pose.getOrigin().y(), 
+					     0.0));
+      test_base_tf_ptr = boost::make_shared<tf::Transform>(test_base_tf);
+      tf::Stamped<tf::Pose> test_base_to_map(*test_base_tf_ptr, 
                                              laser_scan->header.stamp,
                                              test_frame_id_);
       ros::Duration test_transform_tolerance_(0.01);
@@ -1397,6 +1412,7 @@ AmclNode::laserReceived(const sensor_msgs::LaserScanConstPtr& laser_scan)
                                                 transform_expiration,
                                                 global_frame_id_, test_frame_id_);
       this->tfb_->sendTransform(test_base_tf_stamped);
+      sent_first_transform_ = true;
     }
     if(draw_laser_points_){ //draw the laser points adjutsed for pose correction 
       sensor_msgs::PointCloud cloud;
@@ -1509,6 +1525,11 @@ AmclNode::initialPoseReceived(const geometry_msgs::PoseWithCovarianceStampedCons
           pose_new.getOrigin().x(),
           pose_new.getOrigin().y(),
           getYaw(pose_new));
+
+  // If we're in odom-only mode, we want to update the map to odom transform to the new initialpose
+  if(odom_only_) {
+    new_initial_pose_received_ = true;
+  }
   
   // Re-initialize the filter
   pf_vector_t pf_init_pose_mean = pf_vector_zero();


### PR DESCRIPTION
Fixed odom_only mode to take in initialpose
Added param use_tf_to_update_initial_pose which allows you to get rid of the tf-based initialpose update based on the tiny amount the robot has moved since the initialpose was broadcast (which can cause all sorts of problems)
Added pf_update_converged calls to allow beam_skipping to be used even from the start if we start out knowing very well where we are (which gets rid of some of the issues with not being able to manually localize the robot when using likelihood_field_prob)